### PR TITLE
Refresh token is sometimes removed in options

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -351,7 +351,7 @@ GoogleDeviceAuth.prototype._handleUserCodeResponse = function(data) {
  */
 GoogleDeviceAuth.prototype._storeAuthData = function(data) {
   _.extend(this.authData, data);
-  this.options.refreshToken = data.refresh_token;
+  this.options.refreshToken = data.refresh_token || this.options.refreshToken;
   this.emit(events.newAccessToken, data);
 };
 


### PR DESCRIPTION
After authorization with previously stored refresh token, there is no 'refreshToken' field in auth data in response, thus options.refreshToken field was overwritten by 'undefined'.